### PR TITLE
fix segfault when file-browser is destroyed twice

### DIFF
--- a/src/filebrowser.c
+++ b/src/filebrowser.c
@@ -66,6 +66,9 @@ static int file_browser_init ( Mode *sw )
 static void file_browser_destroy ( Mode *sw )
 {
     FileBrowserModePrivateData *pd = ( FileBrowserModePrivateData * ) mode_get_private_data ( sw );
+    if ( ! pd )
+        return;
+
     mode_set_private_data ( sw, NULL );
 
     /* Free file list. */


### PR DESCRIPTION
When I used rofi with rofi-file-browser, I found my dmesg is full of segfault caused by rofi.
This is because rofi may call file_browser_destroy multiple times and get segfault.

I have created[ an issue in rofi repo](https://github.com/davatorium/rofi/issues/1054) which contains details of this bug.