### PR TITLE
Correct and improve manual

### DIFF
--- a/doc/rofi-file-browser-extended.1
+++ b/doc/rofi-file-browser-extended.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "ROFI\-FILE\-BROWSER\-EXTENDED" "1" "January 2022" ""
+.TH "ROFI\-FILE\-BROWSER\-EXTENDED" "1" "May 2022" ""
 .SH "NAME"
 \fBrofi\-file\-browser\-extended\fR \- use rofi to quickly open files
 .SH "SYNOPSIS"
@@ -63,7 +63,7 @@ ls somedir | rofi \-show file\-browser\-extended \-file\-browser\-stdin \-file\-
 .fi
 .IP "" 0
 .SH "CONFIGURATION"
-The default config file location is \fB$XDG_USER_CONFIG_DIR/rofi/file\-browser\fR (usually to \fB$HOME/config/rofi/file\-browser\fR)\. The config file consists of newline\-separated command line options \fBwithout\fR the \fB"\-file\-browser\-"\fR prefix\.
+The default config file location is \fB$XDG_USER_CONFIG_DIR/rofi/file\-browser\fR (usually to \fB$HOME/config/rofi/file\-browser\fR)\. The config file consists of newline\-separated command line options \fBwithout\fR the \fB"\-file\-browser\-"\fR prefix\. Each key and value should be separated by one or more space characters\.
 .P
 Example:
 .IP "" 4
@@ -179,7 +179,7 @@ Set the key binding for \fBopen custom\fR\. \fB(default: \fBkb\-accept\-alt\fR)\
 \fB\-file\-browser\-open\-multi\-key\fR \fI\fIrofi\-key\fR\fR
 Set the key binding for \fBopen multi\fR\. \fB(default: \fBkb\-custom\-1\fR)\fR
 .TP
-\fB\-file\-browser\-open\-toggle\-hidden\fR \fI\fIrofi\-key\fR\fR
+\fB\-file\-browser\-toggle\-hidden\-key\fR \fI\fIrofi\-key\fR\fR
 Set the key binding for toggling hidden files\. \fB(default: \fBkb\-custom\-2\fR)\fR
 .SS "Appearance"
 .TP

--- a/doc/rofi-file-browser-extended.1.html
+++ b/doc/rofi-file-browser-extended.1.html
@@ -156,7 +156,8 @@ ls somedir | rofi -show file-browser-extended -file-browser-stdin -file-browser-
 <h2 id="CONFIGURATION">CONFIGURATION</h2>
 
 <p>The default config file location is <code>$XDG_USER_CONFIG_DIR/rofi/file-browser</code> (usually to <code>$HOME/config/rofi/file-browser</code>).
-The config file consists of newline-separated command line options <strong>without</strong> the <strong>"-file-browser-"</strong> prefix.</p>
+The config file consists of newline-separated command line options <strong>without</strong> the <strong>"-file-browser-"</strong> prefix. Each key and value should be
+separated by one or more space characters.</p>
 
 <p>Example:</p>
 
@@ -342,7 +343,7 @@ Run <code>rofi -dump-config</code> or <code>rofi -dump-xresources</code> to get 
 <strong>(default: <code>kb-custom-1</code>)</strong>
 </dd>
 <dt>
-<code>-file-browser-open-toggle-hidden</code> <em><var>rofi-key</var></em>
+<code>-file-browser-toggle-hidden-key</code> <em><var>rofi-key</var></em>
 </dt>
 <dd>Set the key binding for toggling hidden files.
 <strong>(default: <code>kb-custom-2</code>)</strong>
@@ -419,7 +420,7 @@ If that doesn't help, feel free to create a new issue on GitHub.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>January 2022</li>
+    <li class='tc'>May 2022</li>
     <li class='tr'>rofi-file-browser-extended(1)</li>
   </ol>
 

--- a/doc/rofi-file-browser-extended.1.ronn
+++ b/doc/rofi-file-browser-extended.1.ronn
@@ -76,7 +76,8 @@ Example:
 ## CONFIGURATION
 
 The default config file location is `$XDG_USER_CONFIG_DIR/rofi/file-browser` (usually to `$HOME/config/rofi/file-browser`).
-The config file consists of newline-separated command line options **without** the **"-file-browser-"** prefix.
+The config file consists of newline-separated command line options **without** the **"-file-browser-"** prefix. Each key and value should be
+separated by one or more space characters.
 
 Example:
 
@@ -230,7 +231,7 @@ Run `rofi -dump-config` or `rofi -dump-xresources` to get a list of available op
   Set the key binding for `open multi`.
   **(default: `kb-custom-1`)**
 
-* `-file-browser-open-toggle-hidden` *<rofi-key>*:
+* `-file-browser-toggle-hidden-key` *<rofi-key>*:
   Set the key binding for toggling hidden files.
   **(default: `kb-custom-2`)**
 


### PR DESCRIPTION
I had some troubles configuring the plugin because of some false or missing information in the manual, so I decided to correct it, specifically the following:

* Correct toggle-hidden-key option.
* Make the format of the config clearer.

Cheers,
Yaroslav

P.S: maybe somewhere in the README there should be some information as to how the manual pages should be transpiled to the roff and html formats for future contributors.