### PR TITLE
Fix building with GCC 14 on i686

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -167,7 +167,7 @@ static bool match_glob_patterns ( const char *basename, FileBrowserFileData *fd 
 {
     int len = strlen ( basename );
     for ( int i = 0; i < fd->num_exclude_patterns; i++ ) {
-        if ( g_pattern_match ( fd->exclude_patterns[i], len, basename, NULL ) ) {
+        if ( g_pattern_spec_match ( fd->exclude_patterns[i], len, basename, NULL ) ) {
             return false;
         }
     }

--- a/src/icons.c
+++ b/src/icons.c
@@ -48,7 +48,7 @@ void request_icons_for_file ( FBFile *fbfile, int icon_size, FileBrowserIconData
         }
     }
 
-    unsigned long num_icon_names;
+    gsize num_icon_names;
     char** icon_names_raw = g_array_steal ( icon_names, &num_icon_names );
 
     /* Create icon fetcher requests. */


### PR DESCRIPTION
GCC 14 (and above) have enabled certain compiler flags such as Wincompatible-pointer-types that causes build time errors such as

rofi-file-browser-extended-1.3.1/src/icons.c:52:57: error: passing argument 2 of ‘g_array_steal’ from incompatible pointer type [-Wincompatible-pointer-types]
   52 |     char** icon_names_raw = g_array_steal ( icon_names, &num_icon_names );
      |                                                         ^~~~~~~~~~~~~~~
      |                                                         |
      |                                                         long unsigned int *
In file included from /usr/include/glib-2.0/glib.h:33,
                 from /usr/include/glib-2.0/gmodule.h:30,
                 from /var/tmp/portage/x11-misc/rofi-file-browser-extended-1.3.1-r1/work/rofi-file-browser-extended-1.3.1/src/icons.c:1:
/usr/include/glib-2.0/glib/garray.h:86:54: note: expected ‘gsize *’ {aka ‘unsigned int *’} but argument is of type ‘long unsigned int *’
   86 |                                    gsize            *len);
      |                                    ~~~~~~~~~~~~~~~~~~^~~

My patch attempts to fix this error and some other C99 related warnings. First reported on Gentoo linux, please reffer
https://bugs.gentoo.org/928491 for more details