### PR TITLE
Fix incompatible function pointer types

### DIFF
--- a/src/filebrowser.c
+++ b/src/filebrowser.c
@@ -263,7 +263,7 @@ static char *file_browser_get_display_value ( const Mode *sw, unsigned int selec
     }
 }
 
-static cairo_surface_t *file_browser_get_icon ( const Mode *sw, unsigned int selected_line, int height )
+static cairo_surface_t *file_browser_get_icon ( const Mode *sw, unsigned int selected_line, unsigned int height )
 {
     FileBrowserModePrivateData *pd = ( FileBrowserModePrivateData * ) mode_get_private_data ( sw );
     FileBrowserFileData *fd = &pd->file_data;


### PR DESCRIPTION
Fixes

```
[ 88%] Built target manpage
/tmp/yay-build/rofi-file-browser-extended-git/src/rofi-file-browser-extended/src/filebrowser.c:380:27: error: initialization of ‘cairo_surface_t * (*)(const Mode *, unsigned int,  unsigned int)’ {aka ‘struct _cairo_surface * (*)(const struct rofi_mode *, unsigned int,  unsigned int)’} from incompatible pointer type ‘cairo_surface_t * (*)(const Mode *, unsigned int,  int)’ {aka ‘struct _cairo_surface * (*)(const struct rofi_mode *, unsigned int,  int)’} [-Wincompatible-pointer-types]
  380 |     ._get_icon          = file_browser_get_icon,
      |                           ^~~~~~~~~~~~~~~~~~~~~
/tmp/yay-build/rofi-file-browser-extended-git/src/rofi-file-browser-extended/src/filebrowser.c:380:27: note: (near initialization for ‘mode._get_icon’)
make[2]: *** [CMakeFiles/filebrowser.dir/build.make:90: CMakeFiles/filebrowser.dir/src/filebrowser.c.o] Error 1
```
