### PR TITLE
fix: update rofi function pointer signature

### DIFF
--- a/src/filebrowser.c
+++ b/src/filebrowser.c
@@ -263,7 +263,7 @@ static char *file_browser_get_display_value ( const Mode *sw, unsigned int selec
     }
 }
 
-static cairo_surface_t *file_browser_get_icon ( const Mode *sw, unsigned int selected_line, int height )
+static cairo_surface_t *file_browser_get_icon ( const Mode *sw, unsigned int selected_line, unsigned int height )
 {
     FileBrowserModePrivateData *pd = ( FileBrowserModePrivateData * ) mode_get_private_data ( sw );
     FileBrowserFileData *fd = &pd->file_data;


### PR DESCRIPTION
Updates the function signature to match rofi 1.7.7 (added as of [this commit](https://github.com/davatorium/rofi/commit/0e90fb065f488cde2584e1f0059e169141b04830))

```
rofi-file-browser-extended/src/filebrowser.c:380:27: error: initialization of ‘cairo_surface_t * (*)(const Mode *, unsigned int,  unsigned int)’ {aka ‘struct _cairo_surface * (*)(const struct rofi_mode *, unsigned int,  unsigned int)’} from incompatible pointer type ‘cairo_surface_t * (*)(const Mode *, unsigned int,  int)’ {aka ‘struct _cairo_surface * (*)(const struct rofi_mode *, unsigned int,  int)’} [-Wincompatible-pointer-types]
  380 |     ._get_icon          = file_browser_get_icon,
      |                           ^~~~~~~~~~~~~~~~~~~~~
```

