### PR TITLE
Add sort by modification time

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,11 @@ Key bindings can be changed via command line options (see [Command line options/
 > Sort-by-type is secondary to sort-by-depth if both are enabled.
 > *(default: disabled)*
 
+#### -file-browser-sort-by-mtime, -file-browser-no-sort-by-mtime
+> Enable / disable sort-by-mtime. Sorts files by modification time, where recent modified files are listed on top.
+> Sort-by-mtime overrides both sort-by-type and sort-by-depth.
+> *(default: disabled)*
+
 #### -file-browser-hide-parent
 > Hide the parent directory (`..`).
 > *(default: shown)*

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -2,10 +2,11 @@
 #define FILE_BROWSER_DEFAULTS_H
 
 /* The starting directory. */
-#define START_DIR g_get_current_dir ()
+#define START_DIR g_get_current_dir()
 
 /* The configuration file. */
-#define CONFIG_FILE g_build_filename ( g_get_user_config_dir (), "rofi", "file-browser", NULL )
+#define CONFIG_FILE                                                            \
+  g_build_filename(g_get_user_config_dir(), "rofi", "file-browser", NULL)
 
 /* The default command used to open files. */
 #define CMD "xdg-open \"%s\""
@@ -33,6 +34,9 @@
 
 /* Sort file by depth: files with lower depth first. */
 #define SORT_BY_DEPTH false
+
+/* Sort file by mtime: files with more recent modification time first. */
+#define SORT_BY_MTIME false
 
 /* Print the file path instead of opening the file. */
 #define STDOUT_MODE false
@@ -72,11 +76,14 @@
 #define FALLBACK_ICON "text-x-generic"
 #define ERROR_ICON "error"
 
-/* The message to display when prompting the user to enter the program to open a file with.
-   If the message contains %s, it will be replaced with the file name. */
-#define OPEN_CUSTOM_MESSAGE_FORMAT "Enter command to open '%s' with, or cancel to go back."
+/* The message to display when prompting the user to enter the program to open a
+   file with. If the message contains %s, it will be replaced with the file
+   name. */
+#define OPEN_CUSTOM_MESSAGE_FORMAT                                             \
+  "Enter command to open '%s' with, or cancel to go back."
 
-/* Keys for custom bindings. Only KB_CUSTOM_* and KB_ACCEPT_ALT supported. See types.h. */
+/* Keys for custom bindings. Only KB_CUSTOM_* and KB_ACCEPT_ALT supported. See
+ * types.h. */
 /* Key for opening file with custom command. */
 #define OPEN_CUSTOM_KEY KB_ACCEPT_ALT
 /* Key for opening file without closing. */
@@ -89,7 +96,8 @@
 #define OPEN_CUSTOM_CMD_ICON_SEP ";icon:"
 
 /* The file containing the path for resuming from the last visited directory. */
-#define RESUME_FILE g_build_filename ( g_get_user_config_dir (), "rofi", "file-browser-resume", NULL )
+#define RESUME_FILE                                                            \
+  g_build_filename(g_get_user_config_dir(), "rofi", "file-browser-resume", NULL)
 /* Whether to resume from the last visited directory by default. */
 #define RESUME false
 

--- a/include/types.h
+++ b/include/types.h
@@ -27,6 +27,9 @@ typedef struct {
     /* Depth of the file when listing recursively. */
     unsigned int depth;
 
+    /* Modification time of the file. */
+    __time_t mtime;
+
     /* Rofi icon fetcher request IDs for possible icons. */
     uint32_t *icon_fetcher_requests;
     unsigned int num_icon_fetcher_requests;
@@ -59,6 +62,8 @@ typedef struct {
     bool sort_by_type;
     /* Show files with lower depth first. */
     bool sort_by_depth;
+    /* files with more recent modification time first. */
+    bool sort_by_mtime;
     /* Hide the parent directory (..). */
     bool hide_parent;
     /* Text for the parent directory (..). */

--- a/src/filebrowser.c
+++ b/src/filebrowser.c
@@ -263,7 +263,7 @@ static char *file_browser_get_display_value ( const Mode *sw, unsigned int selec
     }
 }
 
-static cairo_surface_t *file_browser_get_icon ( const Mode *sw, unsigned int selected_line, int height )
+static cairo_surface_t *file_browser_get_icon ( const Mode *sw, unsigned int selected_line, unsigned int height )
 {
     FileBrowserModePrivateData *pd = ( FileBrowserModePrivateData * ) mode_get_private_data ( sw );
     FileBrowserFileData *fd = &pd->file_data;

--- a/src/options.c
+++ b/src/options.c
@@ -132,6 +132,13 @@ bool set_options ( FileBrowserModePrivateData *pd )
     } else {
         fd->sort_by_depth = SORT_BY_DEPTH;
     }
+    if (fb_find_arg("-file-browser-sort-by-mtime", pd)) {
+        fd->sort_by_mtime = true;
+    } else if (fb_find_arg("-file-browser-no-sort-by-mtime", pd)) {
+        fd->sort_by_mtime = false;
+    } else {
+        fd->sort_by_mtime = SORT_BY_MTIME;
+    }
 
     /* Start directory. */
     fd->current_dir = get_start_dir( pd );


### PR DESCRIPTION
Simple implementation to sort files based on modification time (#48)

Adds two new flags for this: `-file-browser-sort-by-mtime` and `-file-browser-no-sort-by-mtime`

The current implementation overrides sort by depth and sort by type.